### PR TITLE
🚀 Laser Power-Up System: Stability fixes, animation flow, and ECS str…

### DIFF
--- a/bagel.h
+++ b/bagel.h
@@ -13,10 +13,10 @@ namespace bagel
 		bool	AggregateUpdates = true;
 		bool	CallbackOnDestroy = true;
 		bool	DynamicResize = false;
-		int		IdBagSize = 5;
-		int		InitialEntities = 100;
-		int		InitialPackedSize = 5;
-		int		MaxComponents = 100;
+		int		IdBagSize = 10000;
+		int		InitialEntities = 10000;
+		int		InitialPackedSize = 10000;
+		int		MaxComponents = 10000;
 	};
 
 	template <class T> struct Storage;

--- a/bagel_cfg.h
+++ b/bagel_cfg.h
@@ -20,5 +20,8 @@ BAGEL_STORAGE(breakout::DestroyedTag, TaggedStorage)
 BAGEL_STORAGE(breakout::FloorTag, TaggedStorage)
 BAGEL_STORAGE(breakout::Sprite, SparseStorage)
 BAGEL_STORAGE(breakout::BrickHealth, SparseStorage)
+BAGEL_STORAGE(breakout::LaserTag, TaggedStorage)
+BAGEL_STORAGE(breakout::StarPowerTag, TaggedStorage)
+
 
 

--- a/breakoutGame/breakout_game.h
+++ b/breakoutGame/breakout_game.h
@@ -32,7 +32,9 @@ namespace breakout {
         BRICK_YELLOW_DMG = 7,
         BRICK_ORANGE = 8,
         BRICK_ORANGE_DMG = 9,
-        LASER = 10
+        LASER = 10,
+        STAR = 11
+
     };
 
     //----------------------------------
@@ -84,7 +86,7 @@ namespace breakout {
 
     /** @brief Temporary effect applied to the entity, with duration */
     struct TimedEffect {
-        float duration = 0.0f; ///< Duration of the temporary effect in seconds
+        float remaining = 0.0f; ///< Remaining time for power-up
     };
 
     /** @brief Number of lives remaining for the player */
@@ -106,6 +108,15 @@ namespace breakout {
     struct BreakAnimation {
         float timer = 0.0f; //seconds
     };
+
+    /** @brief Tag for falling star power-up */
+    struct StarPowerTag {};
+
+    /** @brief Tag to identify laser entities */
+    struct LaserTag {};
+
+
+
 
     //----------------------------------
     // Systems (declarations only)
@@ -129,7 +140,8 @@ namespace breakout {
     /**
      * @brief Activates power-up logic and tracks timed effects.
      */
-    void PowerUpSystem();
+    void PowerUpSystem(float deltaTime);
+
 
     /**
      * @brief Removes entities marked with DestroyedTag.
@@ -150,6 +162,8 @@ namespace breakout {
     void RenderSystem(SDL_Renderer* ren, SDL_Texture* tex);
 
     void BreakAnimationSystem(float deltaTime);
+
+    void StarSystem(float deltaTime);
 
 
     //----------------------------------
@@ -211,6 +225,10 @@ namespace breakout {
      * @param health Health value assigned to each brick.
      */
     void CreateBrickGrid(int rows, int cols, int health);
+
+    id_type CreateStar(float x, float y);
+
+    id_type CreateLaser(float x, float y);
 
 } // namespace breakout
 


### PR DESCRIPTION
…ucture cleanup

Added:
- Laser-based power-up activated by hitting a static star between bricks.
- Laser entities created from paddle every 0.5 seconds during active power-up.
- BreakAnimation component added to bricks hit by lasers, matching ball logic.

Changed:
- `PowerUpSystem`:
  - Uses deltaTime for accurate timing.
  - Cooldown added for controlled laser firing.
  - Skips entities marked with `DestroyedTag`.
- `CollisionSystem`:
  - Refactored to separate laser vs. brick and ball vs. everything else.
  - Added safe logic for marking bricks as destroyed after break animation.
- `BreakAnimationSystem`:
  - Skips destroyed entities.
  - Ensures single `DestroyedTag` addition after timer expires.
- `MovementSystem`:
  - Skips movement for entities marked as destroyed.
  - Warns if a brick incorrectly has a `Velocity` component.
- General:
  - All `addComponent<DestroyedTag>` calls now check if the tag already exists to avoid double-deletion.
  - Removed falling star behavior and replaced with static placement in `CreateBrickGrid`.

 Known issues (not yet resolved):
-  Memory leaks / access violations still occur intermittently (0xC0000005).
- Tried:
  - Checking `DestroyedTag` before every `addComponent`.
  - Skipping movement/render/collision for destroyed entities.
  - Avoiding double collision hits and laser over-generation. → None fully solved the issue yet.

 Result:
- Improved stability and structure.
- Laser system is mostly functional.
- Further debugging needed for full crash prevention.